### PR TITLE
fix(ci): Dependabot auto-merge + repin actions to satisfy zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master, main]
   pull_request:
-    branches: [main]
+    branches: [master, main]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo check
 
@@ -28,11 +30,12 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -40,11 +43,12 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy -- -D warnings
@@ -56,10 +60,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo build --release
 
@@ -68,10 +74,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check, clippy]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Pull Portainer image
         run: docker pull portainer/portainer-ce:2.27.3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,101 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    branches: [ "master" ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-approve and enable auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide eligibility
+        id: decide
+        env:
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPS_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
+        run: |
+          set -euo pipefail
+          eligible=false
+
+          # Auto-merge patch + minor for these ecosystems. Major bumps stay manual
+          # (breaking-change risk). Two safety nets cover these merges:
+          #   1. The `master-required-checks` ruleset blocks any PR whose CI and
+          #      security checks are red — `gh pr merge --auto` waits for them,
+          #      so a broken bump never lands.
+          #   2. dependabot.yml sets a 7-day `cooldown` on every ecosystem, so a
+          #      freshly-published (possibly compromised) release is not pulled
+          #      in until it has been public for a week.
+          #
+          # github_actions : CI config only, low blast radius.
+          # cargo          : Rust deps; this is a deployed binary, not a
+          #                  published library, so a bad bump's blast radius is
+          #                  our own CI/runtime.
+          # docker         : base-image bumps, gated by the CI build and Trivy
+          #                  scans.
+          #
+          # update-type semantics:
+          #   * Single-dependency PRs carry a resolved top-level UPDATE_TYPE
+          #     (version-update:semver-{patch,minor,major}).
+          #   * Grouped PRs (github-actions and cargo each use a `*` group in
+          #     dependabot.yml) and docker digest pins report an EMPTY top-level
+          #     UPDATE_TYPE — fetch-metadata cannot collapse a group into one
+          #     level. For those we judge the per-dependency list in DEPS_JSON
+          #     and stay eligible only when NO member is a semver-major bump.
+          #     Digest pins have a null per-entry updateType, correctly treated
+          #     as not-major.
+          has_major() {
+            # true (exit 0) iff any updated dependency is a semver-major bump.
+            local majors
+            majors=$(printf '%s' "$DEPS_JSON" \
+              | jq '[.[] | select(.updateType == "version-update:semver-major")] | length' \
+              2>/dev/null || echo 1)
+            [[ "$majors" -gt 0 ]]
+          }
+
+          case "$ECOSYSTEM" in
+            cargo|github_actions|docker)
+              if [[ "$UPDATE_TYPE" == "version-update:semver-patch" || \
+                    "$UPDATE_TYPE" == "version-update:semver-minor" ]]; then
+                eligible=true
+              else
+                # Resolved major, or empty level (grouped PRs, digest pins):
+                # judge per-dependency.
+                n=$(printf '%s' "$DEPS_JSON" | jq 'length' 2>/dev/null || echo 0)
+                if [[ "$n" -gt 0 ]] && ! has_major; then
+                  eligible=true
+                fi
+              fi
+              ;;
+          esac
+
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+          echo "ecosystem=$ECOSYSTEM update-type=$UPDATE_TYPE eligible=$eligible deps=$DEPS_JSON"
+
+      - name: Approve PR
+        if: steps.decide.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: gh pr review "$PR_URL" --approve --body "Auto-approved by dependabot-auto-merge workflow (ecosystem=${ECOSYSTEM}, update-type=${UPDATE_TYPE})."
+
+      - name: Enable auto-merge
+        if: steps.decide.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,13 @@ jobs:
             use_cross: false
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # zizmor: ignore[cache-poisoning]
@@ -123,7 +124,7 @@ jobs:
           if-no-files-found: error
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: portainer-stacks-${{ github.ref_name }}-${{ matrix.target }}.${{ matrix.archive }}
 
@@ -142,7 +143,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -194,7 +195,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-name: ghcr.io/guthman/portainer-mcp
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  # pull_request_target is the GitHub-documented pattern for Dependabot auto-merge
+  # (write token needed to approve + enable auto-merge). Our usage is safe: no
+  # actions/checkout of PR code, and all PR-sourced values are passed via env:
+  # vars (never interpolated into shell via ${{ }}).
+  dangerous-triggers:
+    ignore:
+      - dependabot-auto-merge.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,10 +3,7 @@ use std::sync::{Arc, RwLock};
 
 use rmcp::{
     ErrorData as McpError, ServerHandler,
-    handler::server::{
-        router::{prompt::PromptRouter, tool::ToolRouter},
-        wrapper::Parameters,
-    },
+    handler::server::wrapper::Parameters,
     model::{
         AnnotateAble, CallToolResult, Content, GetPromptRequestParams, GetPromptResult,
         ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult, LoggingLevel,
@@ -28,8 +25,6 @@ use crate::redact::{self, EnvDisplayMode, RedactConfig};
 /// Implements [`ServerHandler`] from rmcp and communicates over stdio using JSON-RPC.
 #[derive(Clone)]
 pub struct PortainerServer {
-    tool_router: ToolRouter<Self>,
-    prompt_router: PromptRouter<Self>,
     client: PortainerClient,
     log_level: Arc<RwLock<Option<LoggingLevel>>>,
     redact_config: RedactConfig,
@@ -68,8 +63,6 @@ impl Default for PortainerServer {
 impl PortainerServer {
     pub fn new() -> Self {
         Self {
-            tool_router: Self::tool_router(),
-            prompt_router: Self::prompt_router(),
             client: PortainerClient::new(),
             log_level: Arc::new(RwLock::new(None)),
             redact_config: RedactConfig::from_env(),


### PR DESCRIPTION
Unblocks the four stalled Dependabot PRs. Two commits:

1. **Dependabot auto-merge** (ported from guthman-io-webservices): approves and enables squash auto-merge on patch/minor Dependabot PRs for cargo/github_actions/docker; majors stay manual. Grouped PRs and docker digest pins are judged per-dependency. Also fixes ci.yml triggering on `[main]` only — the default branch is `master`, so CI never ran on PRs. The new `master-required-checks` ruleset makes auto-merge wait for green CI + security scans. Adds a zizmor config exempting the workflow's documented `pull_request_target` pattern.

2. **Repin actions to fix the failing GitHub Actions Security check on every PR**:
   - `dtolnay/rust-toolchain` was pinned to a commit that no longer exists upstream (zizmor `impostor-commit`, High). Repinned to the `v1` tag with `toolchain: stable` as an explicit input.
   - `actions/checkout` / `actions/attest-build-provenance` SHAs didn't match their `# v6` / `# v4` comments (`ref-version-mismatch`). Repinned to the commits those tags point to.

The Trivy failure on the other PRs (rmcp 1.3.0, CVE-2026-42559) is fixed by Dependabot PR #24 itself once it can merge.